### PR TITLE
Broken DMENU hrefs

### DIFF
--- a/intro.html
+++ b/intro.html
@@ -205,7 +205,7 @@ customisable status bars. You can get them here:
     </li>
 
     <li>
-    <a href="http://www.suckless.org/programs/dmenu.html">dmenu</a>
+    <a href="https://tools.suckless.org/dmenu/">dmenu</a>
     </li>
 </ul>
 

--- a/introGHC66.html
+++ b/introGHC66.html
@@ -20,8 +20,8 @@
             </a>
 </td>
         <td>
-        <h2>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;xmonad</h2> 
-        <h2>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;building and installation</h2> 
+        <h2>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;xmonad</h2>
+        <h2>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;building and installation</h2>
         </td>
     </tr>
     </table>
@@ -33,7 +33,7 @@
 </div>
 
 <p>
-xmonad is a <em>tiling window manager</em> for X11. This document 
+xmonad is a <em>tiling window manager</em> for X11. This document
 describes how to build and install xmonad.  For its features and use,
 see the <a href="./tour.html">guided tour</a>.
 </p>
@@ -69,7 +69,7 @@ package systems.  For example, in Debian you would install GHC with:
 <p>
 If your operating system's package system doesn't provide a binary
 version of GHC, you can find pre-built binaries at the <a
-    href="http://haskell.org/ghc">GHC home page</a>. 
+    href="http://haskell.org/ghc">GHC home page</a>.
 It shouldn't be necessary to compile GHC from source -- every common
 system has a pre-build binary version.
 </p>
@@ -191,7 +191,7 @@ chain. The most common problems building xmonad are documented in the
         href="http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#xmonad_does_not_detect_my_multi-head_setup">xmonad does not detect my multi-head setup</a>
     </li>
 
-    <li> <a 
+    <li> <a
         href="http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#Cabal:_Executable_stanza_starting_with_field_.27flag_small_base_description.27">Cabal: Executable stanza starting with field ... </a>
     </li>
 
@@ -230,7 +230,7 @@ customisable status bars. You can get them here:
     </li>
 
     <li>
-    <a href="http://www.suckless.org/programs/dmenu.html">dmenu</a>
+    <a href="https://tools.suckless.org/dmenu/">dmenu</a>
     </li>
 </ul>
 
@@ -397,7 +397,7 @@ cabal-install:
 
     <li> Download and build cabal-install's dependencies <a
         href="http://hackage.haskell.org/cgi-bin/hackage-scripts/package/cabal-install">listed
-        here</a>. Many of these should already be installed. 
+        here</a>. Many of these should already be installed.
     </li>
 
     <li> Download and build <a


### PR DESCRIPTION
editor also removed a few extra spaces at ends of lines