### PR TITLE
Updates to make it easier to see xmonad is in fact alive

### DIFF
--- a/download.html
+++ b/download.html
@@ -110,7 +110,6 @@
             <li><a href="http://gotmor.googlepages.com/dzen">dzen</a>, an extensible status bar</li>
             <li><a href="http://hackage.haskell.org/package/xmobar">xmobar</a>, an extensible status bar</li>
             <li><a href="http://software.schmorp.de/pkg/rxvt-unicode.html">rxvt-unicode</a>, a better terminal</li>
-            <li><a href="http://vimperator.mozdev.net/">vimperator</a>, vim ui for firefox</li>
           </ul>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 
           <h3>What's new?</h3>
           <ul>
-            <li>xmonad 0.15 is available from our <a href="download.html">download page</a>.</li>
+            <li>xmonad 0.15 (2018-09-30) is available from our <a href="download.html">download page</a>.</li>
             <li><a href="https://github.com/xmonad/xmonad/issues">Report a bug</a> and we'll squash it for you in the next release.</li>
             <li>Follow <a href="http://xmonad.wordpress.com/">our
                 blog</a> or <a href="http://twitter.com/xmonad">on

--- a/news.html
+++ b/news.html
@@ -6,7 +6,6 @@
 <head>
     <title>xmonad : news</title>
 <link rel="stylesheet" href="main.css" type="text/css"/>
-<meta http-equiv="refresh" content="0;url=http://xmonad.wordpress.com/">
 </head>
 
 <body>

--- a/news.html
+++ b/news.html
@@ -35,70 +35,15 @@
 
 <a name="6">
 <h3>
-GNOME 3.0 to support tiling window management out of the box!
+xmonad 0.15 Released!
 </h3>
 </a>
 
 <p>
-The <a href="http://xmonad.org/">xmonad</a> project, the world's most
-popular purely functional window manager, is pleased to announce an
-exciting new collaboration with The Free Software Desktop Project,
-creators of the well-known <A
-    href="http://www.gnome.org/">GNOME</a> desktop suite, to 
-enhance and improve the core GNOME system with a focus on the upcoming
-GNOME 3.0 release.
+The xmonad dev team is pleased to announce <a href="http://xmonad.org">xmonad 0.15</a>!
 </p>
 
-<p>
-Addressing the concerns of GNOME users seeking better space utilisation
-for window clients and less dependence on the mouse than existing
-GNOME-compliant window managers provide, the new GNOME 3.0 release will
-include a modified Metacity window manager based on xmonad's "<a
-    href="http://hackage.haskell.org/package/xmonad/docs/XMonad-StackSet.html">StackSet</a>"
-framework for window tiling. Founded on a theory of <a
-    href="http://en.wikipedia.org/wiki/Zipper_(data_structure)">generalised derivatives</a> of
-datatypes, the tiling window management model is expected to produce
-obvious improvements in productivity, scalability and ease of
-use for GNOME users.
-</p>
-
-<p>
-This transition to a "tiling-by-default" approach marks a turning
-point in the history of the open source user interfaces, as the desktop
-metaphor for user interaction is replaced by a more efficient "Rubik's
-cube" model of window/workspace arrangement.
-</p>
-
-<p>
-The xmonad developers, along with Tuomo "tuomov" Valkonen of related Ion
-window manager project, will also be working closely with the GNOME team
-helping transition GNOME to new core components written in Haskell, upon which
-a more robust, maintainable GNOME core will rely. This is expected to
-greatly enhance the long term stability, performance and ease of
-development of GNOME as GNOME developers are able to take advantage of
-powerful user interface tools based on reactive programming, lazy
-evaluation, co-monadic effects and delimited continuations, previously
-unavailable to people who's name wasn't "Oleg".
-</p>
-
-<p>
-The resulting combined GNOME/xmonad code base will also, of course,
-benefit the xmonad project too, with new Perl, Python and C# components from
-GNOME finding their way back into the xmonad codebase, greatly
-increasing the feature range of xmonad, even for those users not using
-GNOME components. By integrating Python and Perl support directly into
-xmonad's core, developers will be able to smoothly script and extend the
-standalone xmonad system without worrying about complicated type errors
-slowing down development and preventing the impossible from happening.
-</p>
-
-<p>
-We hope our users are as excited as the dev team about this new
-collaboration, and expect to see lots of cool new features appearing in
-the GNOME and xmonad codebases soon!
-</p>
-
-<p><small>2008-04-01</small></p>
+<p><small>2018-09-30</small></p>
 
 <a name="5">
 <h3>xmonad 0.7 released!</h3>


### PR DESCRIPTION
0.15 was released in 2018 and works for many people, which is not the impression given by NEWS from 2009 or dead links.