### PR TITLE
Update the link to the Gentoo package

### DIFF
--- a/download.html
+++ b/download.html
@@ -51,7 +51,7 @@
           </div>
           <div class="distros">
             <ul>
-              <li><a href="http://packages.gentoo.org/package/xmonad">Gentoo</a></li>
+              <li><a href="https://packages.gentoo.org/packages/x11-wm/xmonad">Gentoo</a></li>
               <li><a href="http://packages.debian.org/xmonad">Debian</a> (<a href="http://people.debian.org/~jps/etch">etch</a>) </li>
               <li><a href="http://packages.ubuntu.com/search?keywords=xmonad">Ubuntu</a></li>
             </ul>


### PR DESCRIPTION
Generally speaking, the Gentoo packages website supports
the following format:

  https://packages.gentoo.org/packages/$category/$package

nowadays. The link has been updated accordingly. The old
link just returns a 404 nowadays.

Signed-off-by: Max Magorsch <arzano@gentoo.org>