### PR TITLE
Fix links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ _site
 .jekyll-cache
 .jekyll-metadata
 vendor
-_cache/
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # xmonad-web: the website for the xmonad window manager
-The website for [xmonad.org](http://xmonad.org).
+The website for [xmonad.org](https://xmonad.org).
 
 ## Requirements
-The website is built with [jekyll](https://jekyllrb.com/). Check their website
+The website is built with [Jekyll](https://jekyllrb.com/). Check their website
 to get started.
 
 ## Application Structures
@@ -16,8 +16,7 @@ Image should go in the `images` directory.
 The videos that are linked in `videos.html` are hardcoded in
 the `_data/videos.yml`
 
-The `_site` directory is a place for the Hakyll output.
-Hakyll *caches* the website in `_cache`.
+The `_site` directory is a place for the Jekyll output.
 
 ## Contributing
 Contributions to the content as well as to the looks of the website are welcome!

--- a/community.md
+++ b/community.md
@@ -7,12 +7,12 @@ title: Community
 
 ### The xmonad community
 
-*   [the irc channel](http://haskell.org/haskellwiki/IRC_channel): `#xmonad@chat.freenode.org` (join it via [webchat](https://webchat.freenode.net/))
+*   [the irc channel](https://wiki.haskell.org/IRC_channel): `#xmonad@chat.freenode.org` (join it via [webchat](https://webchat.freenode.net/))
 *   [the matrix channel](https://matrix.to/#/#freenode_#xmonad:matrix.org): this is linked to the above IRC channel
-*   [xmonad on twitter](http://twitter.com/xmonad)
+*   [xmonad on twitter](https://twitter.com/xmonad)
 *   [the subreddit](https://old.reddit.com/r/xmonad/)
-*   [the mailing list](https://mail.haskell.org/cgi-bin/mailman/listinfo/xmonad) (archives: [pipermail](http://www.haskell.org/pipermail/xmonad/), [gmane](http://dir.gmane.org/gmane.comp.lang.haskell.xmonad))
-*   [the wiki](http://haskell.org/haskellwiki/Xmonad)
+*   [the mailing list](https://mail.haskell.org/cgi-bin/mailman/listinfo/xmonad) (archives: [pipermail](https://mail.haskell.org/pipermail/xmonad/))
+*   [the wiki](https://wiki.haskell.org/Xmonad)
 
 ### The rest of the intertubes
 
@@ -22,9 +22,9 @@ title: Community
 ### Contribute!
 
 *   report a bug to [xmonad](https://github.com/xmonad/xmonad/issues) or [xmonad-contrib](https://github.com/xmonad/xmonad-contrib/issues)
-*   [garden our wiki](http://haskell.org/haskellwiki/Xmonad)
-*   [garden our wikipedia article](http://en.wikipedia.org/wiki/Xmonad)
-*   [write an extension](http://haskell.org/haskellwiki/Xmonad/xmonad_development_tutorial)
+*   [garden our wiki](https://wiki.haskell.org/Xmonad)
+*   [garden our wikipedia article](https://en.wikipedia.org/wiki/Xmonad)
+*   [write an extension](https://wiki.haskell.org/Xmonad/xmonad_development_tutorial)
 *   [buy a t-shirt](https://www.spreadshirt.com/shop.php?op=article&article_id=2125373)
 
 </div>

--- a/documentation.md
+++ b/documentation.md
@@ -7,36 +7,36 @@ title: Documentation
 
 ## The essentials
 
-*   [the FAQ](http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions)
-*   [the wiki](http://haskell.org/haskellwiki/Xmonad)
+*   [the FAQ](https://wiki.haskell.org/Xmonad/Frequently_asked_questions)
+*   [the wiki](https://wiki.haskell.org/Xmonad)
 *   the documentation:
-    *    [xmonad](http://hackage.haskell.org/package/xmonad)
-    *    [xmonad-contrib](http://hackage.haskell.org/package/xmonad-contrib)
+    *    [xmonad](https://hackage.haskell.org/package/xmonad)
+    *    [xmonad-contrib](https://hackage.haskell.org/package/xmonad-contrib)
 
 ## Getting started
 
 * [about](about.html) – an overview of xmonad features
 * [guided tour](tour.html) – a walkthrough of the basic functionality
-* [step-by-step](http://haskell.org/haskellwiki/Xmonad/Config_archive/John_Goerzen's_Configuration) – guide to configuring xmonad
-* [cheatsheet](http://haskell.org/haskellwiki/Image:Xmbindings.png) – an overview of the keybindings
+* [step-by-step](https://wiki.haskell.org/Xmonad/Config_archive/John_Goerzen's_Configuration) – guide to configuring xmonad
+* [cheatsheet](https://wiki.haskell.org/wikiupload/b/b8/Xmbindings.png) – an overview of the keybindings
 
 ## Reference
 
 * [manpage](manpage.html) – a reference of the default keybindings
-* [configuring](http://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Doc-Configuring.html) – how to write a config file
-* [template xmonad.hs](http://haskell.org/haskellwiki/Xmonad/Config_archive/Template_xmonad.hs) – a complete config file that replicates the defaults
-* [xmonad api docs](http://hackage.haskell.org/package/xmonad) – reference documentation for xmonad's core API
+* [configuring](https://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Doc-Configuring.html) – how to write a config file
+* [template xmonad.hs](https://wiki.haskell.org/Xmonad/Config_archive/Template_xmonad.hs) – a complete config file that replicates the defaults
+* [xmonad api docs](https://hackage.haskell.org/package/xmonad) – reference documentation for xmonad's core API
 
 ## Extensions
 
-* [extending](http://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Doc-Extending.html) – a roundup of many (but not all) of the modules in the _contrib_ package
-* [config archive](http://haskell.org/haskellwiki/Xmonad/Config_archive) – users' contributed config files, showing off many of the extensions
-* [xmonad-contrib api docs](http://hackage.haskell.org/package/xmonad-contrib) – reference documentation for all of xmonad's contrib modules
-* [development tutorial](http://haskell.org/haskellwiki/Xmonad/xmonad_development_tutorial) – learn to write your own extension
+* [extending](https://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Doc-Extending.html) – a roundup of many (but not all) of the modules in the _contrib_ package
+* [config archive](https://wiki.haskell.org/Xmonad/Config_archive) – users' contributed config files, showing off many of the extensions
+* [xmonad-contrib api docs](https://hackage.haskell.org/package/xmonad-contrib) – reference documentation for all of xmonad's contrib modules
+* [development tutorial](https://wiki.haskell.org/Xmonad/xmonad_development_tutorial) – learn to write your own extension
 
 ## In your environment
 
-[Installing from tarball](intro.html) - [Gnome](http://haskell.org/haskellwiki/Xmonad/Using_xmonad_in_Gnome) - [KDE](http://haskell.org/haskellwiki/Xmonad/Using_xmonad_in_KDE) - [XFCE](http://haskell.org/haskellwiki/Xmonad/Using_xmonad_in_XFCE) - [Arch Linux](http://wiki.archlinux.org/index.php/XMonad) - [OS X](http://haskell.org/haskellwiki/Xmonad/Using_xmonad_on_Apple_OSX) - [OLPC](http://haskell.org/haskellwiki/Xmonad/Using_xmonad_on_OLPC_XO)
+[Installing from tarball](intro.html) - [Gnome](https://wiki.haskell.org/Xmonad/Using_xmonad_in_Gnome) - [KDE](https://wiki.haskell.org/Xmonad/Using_xmonad_in_KDE) - [XFCE](https://wiki.haskell.org/Xmonad/Using_xmonad_in_XFCE) - [Arch Linux](https://wiki.archlinux.org/index.php/XMonad) - [OS X](https://wiki.haskell.org/Xmonad/Using_xmonad_on_Apple_OSX) - [OLPC](https://wiki.haskell.org/Xmonad/Using_xmonad_on_OLPC_XO)
 
 </div>
 <div class="col-lg" markdown="1">
@@ -44,13 +44,13 @@ title: Documentation
 # Quick start for the impatient
 
 1.  [Install](download.html) the xmonad binary and config library.
-2.  Wire xmonad up to your [login manager](http://www.haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#How_can_I_use_xmonad_with_a_display_manager.3F_.28xdm.2C_kdm.2C_gdm.29).
+2.  Wire xmonad up to your [login manager](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#How_can_I_use_xmonad_with_a_display_manager.3F_.28xdm.2C_kdm.2C_gdm.29).
 3.  Logout and back in.  You're in xmonad.
 4.  alt-shift-enter to open an xterm.
-5.  Write a ~/.xmonad/xmonad.hs to [configure](http://haskell.org/haskellwiki/Xmonad/Config_archive/John_Goerzen's_Configuration) xmonad.
+5.  Write a ~/.xmonad/xmonad.hs to [configure](https://wiki.haskell.org/Xmonad/Config_archive/John_Goerzen's_Configuration) xmonad.
 6.  mod-q to reload your config file.
 7.  [Install](download.html) the xmonad-contrib config library.
-8.  Edit your xmonad.hs to include this new [fantasticness](http://haskell.org/haskellwiki/Xmonad/Config_archive).
+8.  Edit your xmonad.hs to include this new [fantasticness](https://wiki.haskell.org/Xmonad/Config_archive).
 9.  mod-q to reload your config file.
 
 </div>

--- a/install-instructions.md
+++ b/install-instructions.md
@@ -18,7 +18,7 @@ To build xmonad, you need the GHC Haskell compiler installed. All common operati
 $ apt-get install ghc
 ```
 
-If your operating system's package system doesn't provide a binary version of GHC, you can find pre-built binaries at the [GHC home page](http://haskell.org/ghc). It shouldn't be necessary to compile GHC from source -- every common system has a pre-build binary version.
+If your operating system's package system doesn't provide a binary version of GHC, you can find pre-built binaries at the [GHC home page](https://haskell.org/ghc). It shouldn't be necessary to compile GHC from source -- every common system has a pre-build binary version.
 
 We recommend the latest stable release of GHC.
 
@@ -38,9 +38,9 @@ Typically you need the C libraries: libXinerama libXext libX11
 
 </div>
 
-Recent versions of [Cabal](http://haskell.org/cabal) provide a tool, [cabal-install](http://hackage.haskell.org/package/cabal-install), which automates the building of Haskell libraries, including gathering all dependencies. Your distribution may have a binary package for cabal-install, in which case you should use that. Otherwise the following steps will install it:
+Recent versions of [Cabal](https://haskell.org/cabal) provide a tool, [cabal-install](https://hackage.haskell.org/package/cabal-install), which automates the building of Haskell libraries, including gathering all dependencies. Your distribution may have a binary package for cabal-install, in which case you should use that. Otherwise the following steps will install it:
 
-*   Download [cabal install](http://hackage.haskell.org/package/cabal-install)
+*   Download [cabal install](https://hackage.haskell.org/package/cabal-install)
 *   Run the bootstrap script to install cabal-install with all of it's dependencies into your home directory.
 
     ```
@@ -55,7 +55,7 @@ Recent versions of [Cabal](http://haskell.org/cabal) provide a tool, [cabal-inst
 $ echo "export PATH=$PATH:~/.cabal/bin" >> ~/.profile
 ```
 
-Once you have a working cabal-install, you can then simply install any Haskell package you find on [hackage.haskell.org](http://hackage.haskell.org), such as xmonad, xmonad-contrib or xmobar:
+Once you have a working cabal-install, you can then simply install any Haskell package you find on [hackage.haskell.org](https://hackage.haskell.org), such as xmonad, xmonad-contrib or xmobar:
 
 ```
 $ cabal install xmonad
@@ -71,13 +71,13 @@ $ cabal install xmonad-contrib --flags="-use_xft"
 
 ### If things go wrong..
 
-From time to time people have build problems. Almost always this is due to missing dependencies. Sometimes it is due to problems with the tool chain. The most common problems building xmonad are documented in the [FAQ](http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions):
+From time to time people have build problems. Almost always this is due to missing dependencies. Sometimes it is due to problems with the tool chain. The most common problems building xmonad are documented in the [FAQ](https://wiki.haskell.org/Xmonad/Frequently_asked_questions):
 
-*   [What build dependencies do I need?](http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#What_build_dependencies_does_xmonad_have.3F)
-*   [Can I install without root permission?](http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#Can_I_install_without_root_permission.3F)
-*   [X11 fails to find libX11 or libXinerama](http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#X11_fails_to_find_libX11_or_libXinerama)
-*   [xmonad does not detect my multi-head setup](http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#xmonad_does_not_detect_my_multi-head_setup)
-*   [Cabal: Executable stanza starting with field ...](http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#Cabal:_Executable_stanza_starting_with_field_.27flag_small_base_description.27)
+*   [What build dependencies do I need?](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#What_build_dependencies_does_xmonad_have.3F)
+*   [Can I install without root permission?](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#Can_I_install_without_root_permission.3F)
+*   [X11 fails to find libX11 or libXinerama](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#X11_fails_to_find_libX11_or_libXinerama)
+*   [xmonad does not detect my multi-head setup](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#xmonad_does_not_detect_my_multi-head_setup)
+*   [Cabal: Executable stanza starting with field ...](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#Cabal:_Executable_stanza_starting_with_field_.27flag_small_base_description.27)
 
 If this doesn't help, try asking on the IRC channel, #xmonad @ freenode.org, or on the mailing list.
 
@@ -102,4 +102,4 @@ as the last line of your file, commenting out any previous window manager. Now, 
 
 [![no windows open]({{site.url}}/images/overview/empty.png)]({{site.url}}/images/overview/large/empty.png)
 
-From here, and assuming you can find the **mod1** modifier key (usually 'alt'), you can launch clients and access the rest of the window manager's features. Refer to the [manual page](./manpage.html), or the [cheatsheet](http://haskell.org/haskellwiki/Image:Xmbindings.png)
+From here, and assuming you can find the **mod1** modifier key (usually 'alt'), you can launch clients and access the rest of the window manager's features. Refer to the [manual page](./manpage.html), or the [cheatsheet](https://wiki.haskell.org/wikiupload/b/b8/Xmbindings.png)

--- a/tour.md
+++ b/tour.md
@@ -43,7 +43,7 @@ Note the use of xpmroot to set a background image.
 
 
 * [How to build xmonad by hand](intro.html#comp)
-* [How to use a display manager with xmonad](http://haskell.org/haskellwiki/Xmonad/Frequently_asked_questions#How_can_I_use_xmonad_with_a_display_manager.3F_.28xdm.2C_kdm.2C_gdm.29)
+* [How to use a display manager with xmonad](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#How_can_I_use_xmonad_with_a_display_manager.3F_.28xdm.2C_kdm.2C_gdm.29)
 
 #### Opening clients
 


### PR DESCRIPTION
Fixed some links.

 - Updated several links to haskell wiki.                                                                                               
 - Changed some http links to https.                                                                                                    
 - Changed link to page with info about IRC to [https://wiki.haskell.org/IRC_channel](https://wiki.haskell.org/File:Xmbindings.png)     
 - Changed link to pipermail archives to [https://mail.haskell.org/pipermail/xmonad/](https://mail.haskell.org/pipermail/xmonad/)       
                                                                                                                                        
## To do                                                                                                                                
### Subreddit link                                                                                                                      
Subreddit link in community.md file is for old reddit. Can that be changed to the new version?                                          
                                                                                                                                        
### Gmane                                                                                                                               
The [Gmane link](https://dir.gmane.org/gmane.comp.lang.haskell.xmonad) is no longer working.                                            
                                                                                                                                        
Seems it's not there now as mentioned in issues like [this](https://github.com/wxWidgets/website/issues/32) and [this](https://github.com/python/pythondotorg/issues/1435).                                                       
                                                                                                                                        
Maybe it should be removed? Unless an alternative can be found?                                                                         
                                                                                                                                        
### Hakyll                                                                                                                              
README.md still mentions Hakyll.

Does the site still use it after the move to jekyll? If not, maybe that can be removed as well?       