### PR TITLE
Link to KIWIIRC more often, use internal cheat sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 .jekyll-metadata
 vendor
 Gemfile.lock
+.bundle

--- a/README.md
+++ b/README.md
@@ -5,6 +5,36 @@ The website for [xmonad.org](https://xmonad.org).
 The website is built with [Jekyll](https://jekyllrb.com/). Check their website
 to get started.
 
+The tl;dr is the following:
+
+1. Install some form of `ruby` (and possibly `ruby-devel`) on your
+   system.
+
+2. Install `bundler` and `jekyll` with
+
+   ``` shell
+     $ gem install --user bundler jekyll
+   ```
+
+   Make sure to add the necessary directories to your `$PATH`!
+
+3. Install the required gems locally; you must be in the `xmonad-web`
+   directory for this:
+
+   ``` shell
+     $ bundle config set --local path '.bundle/xmonad-gems'
+     $ bundle install
+   ```
+
+4. Build the website with
+
+   ``` shell
+     $ bundle exec jekyll serve
+   ```
+
+   This should create a browsable copy of the website—and your changes
+   thereof—on `http://127.0.0.1:4000`.
+
 ## Application Structures
 
 All the `.md` files in the root (except for `README.md`) will

--- a/community.md
+++ b/community.md
@@ -7,7 +7,7 @@ title: Community
 
 ### The xmonad community
 
-*   [the irc channel](https://www.haskell.org/irc/): `#xmonad@irc.libera.chat` (join it via [kiwiirc](https://kiwiirc.com/nextclient/irc.libera.chat/?#xmonad))
+*   [the irc channel](https://www.haskell.org/irc/): `#xmonad@irc.libera.chat` (join it via [webchat](https://web.libera.chat/#xmonad))
 *   [xmonad on twitter](https://twitter.com/xmonad)
 *   [the subreddit](https://old.reddit.com/r/xmonad/)
 *   [the mailing list](https://mail.haskell.org/cgi-bin/mailman/listinfo/xmonad) (archives: [pipermail](https://mail.haskell.org/pipermail/xmonad/))

--- a/documentation.md
+++ b/documentation.md
@@ -18,7 +18,7 @@ title: Documentation
 * [about](about.html) – an overview of xmonad features
 * [guided tour](tour.html) – a walkthrough of the basic functionality
 * [step-by-step](https://wiki.haskell.org/Xmonad/Config_archive/John_Goerzen's_Configuration) – guide to configuring xmonad
-* [cheatsheet](https://wiki.haskell.org/wikiupload/b/b8/Xmbindings.png) – an overview of the keybindings
+* [cheatsheet](./images/cheat/xmbindings.png) – an overview of the keybindings
 
 ## Reference
 

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@ layout: header
             </li>
             <li>
                 Follow us on <a href="https://twitter.com/xmonad">twitter</a>, or join the <a href="https://reddit.com/r/xmonad">xmonad
-                subreddit</a>, or come say hi in the IRC channel (#xmonad@irc.libera.chat)!
+                subreddit</a>, or come say hi in the <a href="https://web.libera.chat/#xmonad">IRC channel</a> (#xmonad@irc.libera.chat)!
             </li>
             <li>
                 Checkout some amazing <a href="videos.html">videos</a> about xmonad, and see what other people

--- a/install-instructions.md
+++ b/install-instructions.md
@@ -79,7 +79,7 @@ From time to time people have build problems. Almost always this is due to missi
 *   [xmonad does not detect my multi-head setup](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#xmonad_does_not_detect_my_multi-head_setup)
 *   [Cabal: Executable stanza starting with field ...](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#Cabal:_Executable_stanza_starting_with_field_.27flag_small_base_description.27)
 
-If this doesn't help, try asking on the IRC channel, `#xmonad@irc.libera.chat`, or on the mailing list.
+If this doesn't help, try asking on the IRC channel, `#xmonad@irc.libera.chat` (join it via [webchat](https://web.libera.chat/#xmonad)), or on the mailing list.
 
 #### Grab dmenu and dzen
 


### PR DESCRIPTION
This is a bit of a continuation of #26, with some further things I've noticed since then.

- Link to our version of the xmonad cheat sheet 

  Instead of the wiki version (which is semi-hard to change), we should 
  better link to a version of the image that we control completely.

  For example, in 82b1489 we switched the
  IRC server in the image over to Libera, but the image on the wiki is
  still not updated.

- Link to KIWIIRC more often

  This is perhaps the easiest way for people to connect to IRC, so mention
  it essentially every time that IRC itself is mentioned.

As an additional thing, I've also added a small "quick start" guide on how to get a preview of the website running (which is basically what I did to test this).  I know essentially nothing about Ruby, so this may well be wrong; feel free to correct any step. 
