### PR TITLE
Mention new tutorial, add matrix channel, clean up installation instructions

### DIFF
--- a/community.md
+++ b/community.md
@@ -8,6 +8,7 @@ title: Community
 ### The xmonad community
 
 *   [the irc channel](https://www.haskell.org/irc/): `#xmonad@irc.libera.chat` (join it via [webchat](https://web.libera.chat/#xmonad))
+*   [the libera matrix channel](https://matrix.to/#/#xmonad:libera.chat): this is linked to the IRC channel
 *   [xmonad on twitter](https://twitter.com/xmonad)
 *   [the subreddit](https://old.reddit.com/r/xmonad/)
 *   [the mailing list](https://mail.haskell.org/cgi-bin/mailman/listinfo/xmonad) (archives: [pipermail](https://mail.haskell.org/pipermail/xmonad/))

--- a/documentation.md
+++ b/documentation.md
@@ -17,7 +17,7 @@ title: Documentation
 
 * [about](about.html) – an overview of xmonad features
 * [guided tour](tour.html) – a walkthrough of the basic functionality
-* [step-by-step](https://wiki.haskell.org/Xmonad/Config_archive/John_Goerzen's_Configuration) – guide to configuring xmonad
+* [step-by-step](https://github.com/xmonad/xmonad/blob/master/TUTORIAL.md) – guide to configuring xmonad
 * [cheatsheet](./images/cheat/xmbindings.png) – an overview of the keybindings
 
 ## Reference
@@ -47,7 +47,7 @@ title: Documentation
 2.  Wire xmonad up to your [login manager](https://wiki.haskell.org/Xmonad/Frequently_asked_questions#How_can_I_use_xmonad_with_a_display_manager.3F_.28xdm.2C_kdm.2C_gdm.29).
 3.  Logout and back in.  You're in xmonad.
 4.  alt-shift-enter to open an xterm.
-5.  Write a ~/.xmonad/xmonad.hs to [configure](https://wiki.haskell.org/Xmonad/Config_archive/John_Goerzen's_Configuration) xmonad.
+5.  Write a ~/.xmonad/xmonad.hs to [configure](https://github.com/xmonad/xmonad/blob/master/TUTORIAL.md) xmonad.
 6.  mod-q to reload your config file.
 7.  [Install](download.html) the xmonad-contrib config library.
 8.  Edit your xmonad.hs to include this new [fantasticness](https://wiki.haskell.org/Xmonad/Config_archive).

--- a/documentation.md
+++ b/documentation.md
@@ -24,7 +24,6 @@ title: Documentation
 
 * [manpage](manpage.html) – a reference of the default keybindings
 * [configuring](https://hackage.haskell.org/package/xmonad-contrib/docs/XMonad-Doc-Configuring.html) – how to write a config file
-* [template xmonad.hs](https://wiki.haskell.org/Xmonad/Config_archive/Template_xmonad.hs) – a complete config file that replicates the defaults
 * [xmonad api docs](https://hackage.haskell.org/package/xmonad) – reference documentation for xmonad's core API
 
 ## Extensions

--- a/install-instructions.md
+++ b/install-instructions.md
@@ -102,4 +102,4 @@ as the last line of your file, commenting out any previous window manager. Now, 
 
 [![no windows open]({{site.url}}/images/overview/empty.png)]({{site.url}}/images/overview/large/empty.png)
 
-From here, and assuming you can find the **mod1** modifier key (usually 'alt'), you can launch clients and access the rest of the window manager's features. Refer to the [manual page](./manpage.html), or the [cheatsheet](https://wiki.haskell.org/wikiupload/b/b8/Xmbindings.png)
+From here, and assuming you can find the **mod1** modifier key (usually 'alt'), you can launch clients and access the rest of the window manager's features. Refer to the [manual page](./manpage.html), or the [cheatsheet](./images/cheat/xmbindings.png)

--- a/install-instructions.md
+++ b/install-instructions.md
@@ -4,25 +4,29 @@ title: Install Instructions
 
 xmonad is a _tiling window manager_ for X11\. This document describes how to build and install xmonad. For its features and use, see the [guided tour](./tour.html).
 
-### Use a pre-built binary
+## Use a pre-built binary
 
 Your operating system distribution may have binary packages for xmonad already, or perhaps, many of their dependencies. If at all possible, use one of these pre-built packages. See the [main page](index.html) for distributions that distribute xmonad binaries.
+
+## Building from source
 
 Building xmonad from source is simple. It requires a basic Haskell toolchain, only. We'll now walk through the complete list of toolchain dependencies.
 
 ### Install GHC
 
+Note that, if you decide to install xmonad with stack (see further down), this step is not strictly necessary; stack will download the appropriate version of GHC by itself.
+
 To build xmonad, you need the GHC Haskell compiler installed. All common operating systems provide prebuilt binaries of GHC in their package systems. For example, in Debian you would install GHC with:
 
 ```
-$ apt-get install ghc
+    $ apt-get install ghc
 ```
 
 If your operating system's package system doesn't provide a binary version of GHC, you can find pre-built binaries at the [GHC home page](https://haskell.org/ghc). It shouldn't be necessary to compile GHC from source -- every common system has a pre-build binary version.
 
 We recommend the latest stable release of GHC.
 
-### X11 libraries
+### Install the Necessary C Libraries
 
 Since you're building an X application, you'll need the C X11 library headers. On many platforms, these come pre-installed. For others, such as Debian, you can get them from your package manager:
 
@@ -30,44 +34,19 @@ Since you're building an X application, you'll need the C X11 library headers. O
     $ apt-get install libx11-dev
 ```
 
-Typically you need the C libraries: libXinerama libXext libX11
+Typically you need the C libraries: `libXinerama` `libXext` `libX11`.
 
-<div id="cabal-install">
-
-### Cabal-install
-
-</div>
-
-Recent versions of [Cabal](https://haskell.org/cabal) provide a tool, [cabal-install](https://hackage.haskell.org/package/cabal-install), which automates the building of Haskell libraries, including gathering all dependencies. Your distribution may have a binary package for cabal-install, in which case you should use that. Otherwise the following steps will install it:
-
-*   Download [cabal install](https://hackage.haskell.org/package/cabal-install)
-*   Run the bootstrap script to install cabal-install with all of it's dependencies into your home directory.
-
-    ```
-    $ tar xzf cabal-install-1.24.0.2.tar.gz
-    $ cd cabal-install-1.24.0.2/
-    $ ./bootstrap.sh
-    ```
-
-*   Add ~/.cabal/bin to your $PATH
+Further, since xmonad is build with XFT support by default, you will also need the `libxft` C headers:
 
 ```
-$ echo "export PATH=$PATH:~/.cabal/bin" >> ~/.profile
+    $ apt-get install libxft-dev
 ```
 
-Once you have a working cabal-install, you can then simply install any Haskell package you find on [hackage.haskell.org](https://hackage.haskell.org), such as xmonad, xmonad-contrib or xmobar:
+### Install XMonad
 
-```
-$ cabal install xmonad
-```
+You are now ready to install xmonad with either stack or cabal. For these tool specific instructions, see the [INSTALL.md] document in the core xmonad repo.
 
-#### Note
-
-xmonad-contrib requires you to install libxft C headers, unless you install it without xft support:
-
-```
-$ cabal install xmonad-contrib --flags="-use_xft"
-```
+[INSTALL.md]: https://github.com/xmonad/xmonad/blob/master/INSTALL.md
 
 ### If things go wrong..
 

--- a/tour.md
+++ b/tour.md
@@ -5,6 +5,10 @@ title: Guided Tour
 
 This is a guided tour of the core features of the xmonad window manager, allowing you to gain an understanding of the motivation, and use of a tiling window manager, and learn how to achieve the kind of screen configuration you want, simply and easily.
 
+If you're already familiar with the basics and want to learn how to configure xmonad, head over to the [tutorial]!
+
+[tutorial]: https://github.com/xmonad/xmonad/blob/master/TUTORIAL.md
+
 <div class="row" >
 <div class="col-6" markdown="1" >
 


### PR DESCRIPTION
This is another potpourri of different things that I noticed while
scrolling through the website—especially now that the tutorial got
merged.

1. Mention the new instead of the old tutorial

2. Link to our cheat-sheet everywhere

   A small thing that was missed in 8e5e7d314b3eda2135a8c1d6cbd7bf9eb776bcfa

3. Update install instructions to include INSTALL.md

   The install instructions still tell people to install via a cabal
   install, which is a bad idea now that v3-style commands became the
   default. This kind of global install will almost certainly break once
   the users updates xmonad to a newer version. Cabal-env [1] will perhaps
   remedy this at some point, but for now it's safer that users do not
   install us as a global library.

   Because we already have installation instructions for stack in the
   core repo, just link to them instead of duplicating that information
   on the website.

   [1]: https://github.com/phadej/cabal-extras

4. Remove link to template file

   Using the defaults as some sort of template file is a bad idea,
   especially when we link to an old darcs version that may or may not
   even be relevant anymore.  One should rather only modify parts one
   cares about; something that's even mentioned in the docs of the
   current default config [2].

   [2]: https://github.com/xmonad/xmonad/blob/master/src/XMonad/Config.hs#L15-L17

5. Add link to matrix channel

   Matrix.org now has support for bridging to Libera.