### PR TITLE
Mention matrix channel, Overhaul quick start

### DIFF
--- a/community.md
+++ b/community.md
@@ -9,7 +9,7 @@
 ### The xmonad community
 
 *   [the irc channel](https://www.haskell.org/irc/): `#xmonad@irc.libera.chat` (join it via [webchat](https://web.libera.chat/#xmonad))
-*   [the libera matrix channel](https://matrix.to/#/#xmonad:libera.chat): this is linked to the IRC channel
+*   [the matrix room](https://matrix.to/#/#xmonad:matrix.org), linked to our IRC channel
 *   [xmonad on twitter](https://twitter.com/xmonad)
 *   [the subreddit](https://old.reddit.com/r/xmonad/)
 *   [the mailing list](https://mail.haskell.org/cgi-bin/mailman/listinfo/xmonad) (archives: [pipermail](https://mail.haskell.org/pipermail/xmonad/))

--- a/documentation.md
+++ b/documentation.md
@@ -45,15 +45,12 @@
 
 # Quick start for the impatient
 
-1.  [Install](download.md) the xmonad binary and config library.
+1.  [Install](download.md) the `xmonad` binary/library and the `xmonad-contrib` library.
 2.  Wire xmonad up to your [login manager](INSTALL.md#make-xmonad-your-window-manager).
 3.  Logout and back in.  You're in xmonad.
-4.  alt-shift-enter to open an xterm.
-5.  Write a ~/.xmonad/xmonad.hs to [configure](TUTORIAL.md) xmonad.
-6.  mod-q to reload your config file.
-7.  [Install](download.md) the xmonad-contrib config library.
-8.  Edit your xmonad.hs to include this new [fantasticness](https://wiki.haskell.org/Xmonad/Config_archive).
-9.  mod-q to reload your config file.
+4.  `M-S-<Enter>` to open an xterm.
+5.  Write a `~/.config/xmonad/xmonad.hs` to [configure](https://github.com/xmonad/xmonad/blob/master/TUTORIAL.md) xmonad.
+6.  `M-q` to reload your config file.
 
 </div>
 </div>


### PR DESCRIPTION
Look, it's a PR that I forgot about for a few months

##### Mention other matrix channel

As this is now also linked to IRC and not its own island anymore.

##### Overhaul quick start

The quick start, as it stood, did not make much sense.  The linked
tutorial already assumes that the user has installed xmonad-contrib as a
library, so this should be mentioned further up.

Further, at this point it is perhaps not advisable to link to the config
archive, which holds a lot of old configurations but basically no
up-to-date ones.  The tutorial already links to some maintainers'
configurations, which should be enough to get a glimpse of what's
possible.

In order to not get into trouble of alt vs. mod, the keybindings where
also changed to the more agnostic EZConfig-like syntax.