### PR TITLE
community: List our Named supporters and link to GH Sponsors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ serve: .bundle/.done
 .PHONY: clean
 clean:
 	$(RM) -r Gemfile.lock .bundle _site
+
+_data/sponsors-named.json: _sponsors.sh
+	./_sponsors.sh named-sponsors xmonad >$@

--- a/_data/sponsors-named.json
+++ b/_data/sponsors-named.json
@@ -1,0 +1,26 @@
+[
+  {
+    "login": "agentjsmith",
+    "name": null,
+    "url": "https://github.com/agentjsmith",
+    "websiteUrl": null
+  },
+  {
+    "login": "aniravi24",
+    "name": "Ani Ravi",
+    "url": "https://github.com/aniravi24",
+    "websiteUrl": "https://aniravi.com"
+  },
+  {
+    "login": "jchia",
+    "name": "Joshua Chia",
+    "url": "https://github.com/jchia",
+    "websiteUrl": null
+  },
+  {
+    "login": "joukokar",
+    "name": "Jouko Karvonen",
+    "url": "https://github.com/joukokar",
+    "websiteUrl": null
+  }
+]

--- a/_sponsors.sh
+++ b/_sponsors.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+shopt -s lastpipe inherit_errexit
+
+function o { printf -->&2 "%s:%s\\n" "${0##*/}" "$(printf " %q" "$@")"; "$@"; }
+
+function gh-org-sponsors-tiers {
+	# shellcheck disable=SC2016
+	gh api graphql -F org="${1:?org}" -f query='
+		query Tiers($org: String!) {
+			organization(login: $org) {
+				... on Sponsorable {
+					sponsorsListing {
+						tiers(first: 100) {
+							nodes {
+								id
+								name
+								description
+								monthlyPriceInDollars
+							}
+						}
+					}
+				}
+			}
+		}
+	' --jq '.data.organization.sponsorsListing.tiers.nodes[]'
+}
+
+function gh-org-sponsors-at-tier {
+	# shellcheck disable=SC2016
+	gh api graphql --paginate -F org="${1:?org}" -F tier="${2:?tier}" -f query='
+		query Sponsors($endCursor: String, $org: String!, $tier: ID!) {
+			organization(login: $org) {
+				... on Sponsorable {
+					sponsors(first: 100, tierId: $tier, after: $endCursor) {
+						nodes {
+							... on User         { login, name, url, websiteUrl }
+							... on Organization { login, name, url, websiteUrl }
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	' --jq '.data.organization.sponsors.nodes[]'
+}
+
+function gh-org-sponsors {
+	# shellcheck disable=SC2016
+	gh api graphql --paginate -F org="${1:?org}" -f query='
+		query Sponsors($endCursor: String, $org: String!) {
+			organization(login: $org) {
+				... on Sponsorable {
+					sponsors(first: 100, after: $endCursor) {
+						nodes {
+							... on User         { login, name, url, websiteUrl }
+							... on Organization { login, name, url, websiteUrl }
+						}
+						pageInfo {
+							hasNextPage
+							endCursor
+						}
+					}
+				}
+			}
+		}
+	' --jq '.data.organization.sponsors.nodes[]'
+}
+
+function jq-tierids-since {
+	jq --arg since "${1:?since}" -s -r 'until(.[0].description | contains($since); del(.[0])) | .[].id'
+}
+
+function jq-sort-by {
+	jq -s "sort_by(.${1:?key}) | .[]"
+}
+
+function named-sponsors {
+	o gh-org-sponsors-tiers "${1:?org}" | jq-tierids-since XMonad.Layout.Named | tac | \
+		while read -r tier; do
+			o gh-org-sponsors-at-tier "${1:?org}" "$tier" | jq-sort-by login
+		done | \
+		jq -s ''
+}
+
+"$@"

--- a/community.md
+++ b/community.md
@@ -33,7 +33,7 @@
 
 ### Credits
 
-the xmonad developer team:
+The xmonad developer team:
 
 <div class="list-col-3" markdown="1">
 
@@ -47,7 +47,7 @@ the xmonad developer team:
 
 </div>
 
-hall of fame (no longer active in the project):
+Hall of fame (no longer active in the project):
 
 <div class="list-col-3" markdown="1">
 
@@ -69,10 +69,25 @@ hall of fame (no longer active in the project):
 
 </div>
 
-thanks:
+Thanks:
 
 * [xmonad contributors](https://github.com/xmonad/xmonad/graphs/contributors)
 * [xmonad-contrib contributors](https://github.com/xmonad/xmonad-contrib/graphs/contributors)
+
+### Supporters
+
+Maintenance and development of xmonad is being financially supported by:
+
+<ul>
+{% for sponsor in site.data.sponsors-named %}
+<li><a href="{{ sponsor.websiteUrl | default: sponsor.url }}">{{ sponsor.name | default: sponsor.login | escape }}</a></li>
+{% endfor %}
+<li>and many <a href="https://github.com/sponsors/xmonad#sponsors">others</a></li>
+</ul>
+
+We're grateful for this support, and we humbly ask you to consider [becoming a
+supporter as well](https://github.com/sponsors/xmonad) if you aren't already.
+Thank you!
 
 </div>
 </div>

--- a/community.md
+++ b/community.md
@@ -8,25 +8,25 @@
 
 ### The xmonad community
 
-*   [the irc channel](https://www.haskell.org/irc/): `#xmonad@irc.libera.chat` (join it via [webchat](https://web.libera.chat/#xmonad))
-*   [the matrix room](https://matrix.to/#/#xmonad:matrix.org), linked to our IRC channel
-*   [xmonad on twitter](https://twitter.com/xmonad)
-*   [the subreddit](https://old.reddit.com/r/xmonad/)
-*   [the mailing list](https://mail.haskell.org/cgi-bin/mailman/listinfo/xmonad) (archives: [pipermail](https://mail.haskell.org/pipermail/xmonad/))
-*   [the wiki](https://wiki.haskell.org/Xmonad)
+* [the irc channel](https://www.haskell.org/irc/): `#xmonad@irc.libera.chat` (join it via [webchat](https://web.libera.chat/#xmonad))
+* [the matrix room](https://matrix.to/#/#xmonad:matrix.org), linked to our IRC channel
+* [xmonad on twitter](https://twitter.com/xmonad)
+* [the subreddit](https://old.reddit.com/r/xmonad/)
+* [the mailing list](https://mail.haskell.org/cgi-bin/mailman/listinfo/xmonad) (archives: [pipermail](https://mail.haskell.org/pipermail/xmonad/))
+* [the wiki](https://wiki.haskell.org/Xmonad)
 
 ### The rest of the intertubes
 
-*   [videos about xmonad](videos.html)
-*   [twitter buzz about xmonad](https://twitter.com/search?q=xmonad)
+* [videos about xmonad](videos.html)
+* [twitter buzz about xmonad](https://twitter.com/search?q=xmonad)
 
 ### Contribute!
 
-*   report a bug to [xmonad](https://github.com/xmonad/xmonad/issues) or [xmonad-contrib](https://github.com/xmonad/xmonad-contrib/issues)
-*   [garden our wiki](https://wiki.haskell.org/Xmonad)
-*   [garden our wikipedia article](https://en.wikipedia.org/wiki/Xmonad)
-*   [write an extension](https://wiki.haskell.org/Xmonad/xmonad_development_tutorial)
-*   [buy a t-shirt](https://www.spreadshirt.com/shop/clothing/t-shirts/xmonad/)
+* report a bug to [xmonad](https://github.com/xmonad/xmonad/issues) or [xmonad-contrib](https://github.com/xmonad/xmonad-contrib/issues)
+* [garden our wiki](https://wiki.haskell.org/Xmonad)
+* [garden our wikipedia article](https://en.wikipedia.org/wiki/Xmonad)
+* [write an extension](https://wiki.haskell.org/Xmonad/xmonad_development_tutorial)
+* [buy a t-shirt](https://www.spreadshirt.com/shop/clothing/t-shirts/xmonad/)
 
 </div>
 <div class="col-lg" markdown="1">
@@ -37,13 +37,13 @@ the xmonad developer team:
 
 <div class="list-col-3" markdown="1">
 
-*   [Brandon S Allbery](https://github.com/geekosaur)
-*   [Brent Yorgey](https://byorgey.wordpress.com/)
-*   [Daniel Wagner](http://www.dmwit.com/)
-*   [Sibi Prabakaran](https://psibi.in/)
-*   [slotThe](https://github.com/slotThe)
-*   [Tomáš Janoušek](https://work.lisk.in/)
-*   [Yecine Megdiche](https://github.com/TheMC47)
+* [Brandon S Allbery](https://github.com/geekosaur)
+* [Brent Yorgey](https://byorgey.wordpress.com/)
+* [Daniel Wagner](http://www.dmwit.com/)
+* [Sibi Prabakaran](https://psibi.in/)
+* [slotThe](https://github.com/slotThe)
+* [Tomáš Janoušek](https://work.lisk.in/)
+* [Yecine Megdiche](https://github.com/TheMC47)
 
 </div>
 
@@ -51,28 +51,28 @@ hall of fame (no longer active in the project):
 
 <div class="list-col-3" markdown="1">
 
-*   [Spencer Janssen](https://github.com/spencerjanssen)
-*   [Don Stewart](https://donsbot.wordpress.com/)
-*   [Adam Vogt](https://www.eng.uwaterloo.ca/~aavogt/)
-*   [David Roundy](https://sites.science.oregonstate.edu/~roundyd/people.html)
-*   [Daniel Schoepe](https://github.com/dschoepe)
-*   [Eric Mertens](https://github.com/glguy)
-*   [Nicolas Pouillard](https://nicolaspouillard.fr/)
-*   [Roman Cheplyaka](https://ro-che.info/)
-*   [Gwern Branwen](https://www.gwern.net/)
-*   [Lukas Mai](https://github.com/mauke)
-*   [Braden Shepherdson](https://braincrater.wordpress.com/)
-*   [Devin Mullins](https://twifkak.com/)
-*   [David Lazar](https://davidlazar.org/)
-*   [Peter J. Jones](https://github.com/pjones)
-*   [Peter Simons](http://cryp.to/)
+* [Spencer Janssen](https://github.com/spencerjanssen)
+* [Don Stewart](https://donsbot.wordpress.com/)
+* [Adam Vogt](https://www.eng.uwaterloo.ca/~aavogt/)
+* [David Roundy](https://sites.science.oregonstate.edu/~roundyd/people.html)
+* [Daniel Schoepe](https://github.com/dschoepe)
+* [Eric Mertens](https://github.com/glguy)
+* [Nicolas Pouillard](https://nicolaspouillard.fr/)
+* [Roman Cheplyaka](https://ro-che.info/)
+* [Gwern Branwen](https://www.gwern.net/)
+* [Lukas Mai](https://github.com/mauke)
+* [Braden Shepherdson](https://braincrater.wordpress.com/)
+* [Devin Mullins](https://twifkak.com/)
+* [David Lazar](https://davidlazar.org/)
+* [Peter J. Jones](https://github.com/pjones)
+* [Peter Simons](http://cryp.to/)
 
 </div>
 
 thanks:
 
-*   [xmonad contributors](https://github.com/xmonad/xmonad/graphs/contributors)
-*   [xmonad-contrib contributors](https://github.com/xmonad/xmonad-contrib/graphs/contributors)
+* [xmonad contributors](https://github.com/xmonad/xmonad/graphs/contributors)
+* [xmonad-contrib contributors](https://github.com/xmonad/xmonad-contrib/graphs/contributors)
 
 </div>
 </div>


### PR DESCRIPTION
We promised to list Named sponsors as supporters, so we better deliver soon. :-)

Rendered here: https://liskin.github.io/xmonad-web/community.html

Suggestions to improve the wording very welcome, I'm extremely bad at non-technical writing.

---

#### [community: Reindent](../commit/242c46264081a3f945abbbe4ac04bb06c2edf8b1)


#### [community: List our Named supporters and link to GH Sponsors](../commit/4f8aa6476e06a67db53d8d4f87d3fcaeea7aa6fd)

This comes with code to automatically regenerate the list, but GitHub
currently exposes private sponsors without any way to distinguish them
from public, so I'm not including any GH Actions workflow to regenerate
this periodically, as this still unfortunately needs human oversight.
