### PR TITLE
Add 0.18.2 release notes

### DIFF
--- a/news/_posts/2026-03-06-xmonad-0-18-2.md
+++ b/news/_posts/2026-03-06-xmonad-0-18-2.md
@@ -1,0 +1,145 @@
+---
+title: xmonad 0.18.1 and xmonad-contrib 0.18.2 are available
+image: images/logo-wordmark.png
+---
+
+New versions of xmonad and xmonad-contrib have been released.
+Check out our
+[download page]({{ site.baseurl }}{% link download.md %})
+for instructions on where to get them.
+For help getting started—or more info—see [our website][xmonad.org] and [talk to us][community]!
+If you like what we do, you can support us on [Open Collective] or via [GitHub Sponsors].
+Thanks!
+
+[GitHub Sponsors]: https://github.com/sponsors/xmonad
+[Open Collective]: https://opencollective.com/xmonad
+[community]: https://xmonad.org/community.html
+[xmonad.org]: https://xmonad.org/
+
+### Table of Contents
+{:.no_toc}
+
+  + TOC
+  {:toc}
+
+## xmonad 0.18.1
+
+<!-- $ git shortlog v0.18.0..origin/master --summary | awk '{ sum += $1; count += 1 } END { print sum, count }' -->
+This release includes 87 commits by 10 contributors!
+For a full summary of all the changes, see [xmonad's CHANGES.md] file.
+
+[xmonad's CHANGES.md]: https://github.com/xmonad/xmonad/blob/v0.18.1/CHANGES.md
+
+### Breaking Changes
+
+ * Use `cabal` for `--recompile` if there is a `.cabal` file in the config
+   directory and none of `build`, `stack.yaml`, `flake.nix`, nor `default.nix`
+   exist.
+
+## xmonad-contrib 0.18.2
+
+<!-- $ git shortlog v0.18.1..origin/master --summary | awk '{ sum += $1; count += 1 } END { print sum, count }' -->
+This release includes 127 commits by 15 contributors!
+For a full summary of all the changes, see [xmonad-contrib's CHANGES.md] file.
+
+[xmonad-contrib's CHANGES.md]: https://github.com/xmonad/xmonad-contrib/blob/v0.18.2/CHANGES.md
+
+### Breaking Changes
+
+  * Drop support for GHC 8.6
+
+### New Modules
+
+  * `XMonad.Util.StickyWindows`
+
+    - Stick windows on screens so they follow you across desktops.
+
+### Bug Fixes and Minor Changes
+
+  * `XMonad.Actions.WindowBringer`
+
+    - Make sure functions that internally use their `…Args` versions
+      pass on the default `dmenu` arguments.
+
+      These are also now exported as `defaultDMenuArgs` for users using
+      the `…Args` versions but want to augment instead of replacing the
+      default `dmenu` arguments.
+
+      For users, the visible change will be that `bringMenu` and `copyMenu`
+      now behave identically to `gotoMenu`, as expected, instead of being
+      case sensitive. Users who might have been relying on the incorrect
+      behavior should replace `*Menu` with `*MenuArgs []`.
+
+  * `XMonad.Util.XSelection`
+
+    - Added `getClipboard` to query the X clipboard.
+      Also added `getSecondarySelection`.
+
+  * `XMonad.Util.EZConfig`
+
+    - Added `XF86WLAN` and `Menu` to the list of supported special keys.
+
+  * `XMonad.Actions.DynamicProjects`
+
+    - No longer autodelete projects when `switchProject` is called from
+      an empty workspace. This also fixes a bug where static workspaces
+      would be deleted when switching to a dynamic project.
+    - Improved documentation on how to close a project.
+
+  * `XMonad.Hooks.Rescreen`
+
+    - Allow overriding the `rescreen` operation itself. Additionally, the
+      `XMonad.Actions.PhysicalScreens` module now provides an alternative
+      implementation of `rescreen` that avoids reshuffling the workspaces if
+      the number of screens doesn't change and only their locations do (which
+      is especially common if one uses `xrandr --setmonitor` to split an
+      ultra-wide display in two).
+
+    - Added an optional delay when waiting for events to settle. This may be
+      used to avoid flicker and unnecessary workspace reshuffling if multiple
+      `xrandr` commands are used to reconfigure the display layout.
+
+  * `XMonad.Layout.NoBorders`
+
+    - It's no longer necessary to use `borderEventHook` to garbage collect
+      `alwaysHidden`/`neverHidden` lists. The layout listens to
+      `DestroyWindowEvent` messages instead, which are broadcast to layouts
+      since xmonad v0.17.0.
+
+  * `XMonad.Hooks.EwmhDesktops`
+
+    - Added a customization option for the action that gets executed when
+      a client sends a `_NET_CURRENT_DESKTOP` request. It is now possible
+      to change it using the `setEwmhSwitchDesktopHook`.
+    - Added a customization option for mapping hidden workspaces to screens
+      when setting the `_NET_DESKTOP_VIEWPORT`. This can be done using
+      the `setEwmhHiddenWorkspaceToScreenMapping`.
+
+    - Added support for `_NET_WM_STATE_{ABOVE,BELOW}` to place windows
+      correctly.
+
+  * `XMonad.Layout.IndependentScreens`
+
+    - Added `focusWorkspace` for focusing workspaces on the screen that they
+      belong to.
+    - Added `doFocus'` hook as an alternative for `doFocus` when using
+      IndependentScreens.
+    - Added `screenOnMonitor` for getting the active screen for a monitor.
+
+  * `XMonad.Util.NamedScratchPad`
+
+    - Fix unintended window hiding in `nsSingleScratchpadPerWorkspace`.
+      Only hide the previously active scratchpad.
+
+  * `XMonad.Actions.Search`
+
+    - Added `multiChar`, `combineChar`, and `prefixAwareChar` as
+      slightly generalised versions of `prefixAware` and `(!>)` that
+      allow specifying the character that separates a search engine's
+      prefix with the query when combining engines.
+
+    - Added the `ecosia` search engine.
+
+  * `XMonad.Hooks.ManageDocks`
+
+    - Added `onAllDocks` to run an action on all recognised docks.


### PR DESCRIPTION
I'm not sure if we should actually release `xmonad` 0.18.1, given that it has essentially one user-facing change. On the other hand, now seems as good a time as any to do that—not like core will get many more new features anytime soon :)